### PR TITLE
fix: use context storage for dolos 0.12.0+

### DIFF
--- a/packages/dolos/dolos-0.12.0.yaml
+++ b/packages/dolos/dolos-0.12.0.yaml
@@ -15,8 +15,8 @@ installSteps:
         - daemon
       binds:
         - '{{ .Paths.DataDir }}:/etc/dolos'
-        - '{{ .Paths.DataDir }}/data:/data'
         - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+        - '{{ .Paths.ContextDir }}/dolos-data:/data'
         - '{{ .Paths.ContextDir }}/dolos-ipc:/ipc'
       ports:
         - "30013"


### PR DESCRIPTION
Closes #9 