### PR TITLE
feat(dingo): dingo-txtop wrapper script

### DIFF
--- a/packages/dingo/dingo-0.3.4.yaml
+++ b/packages/dingo/dingo-0.3.4.yaml
@@ -23,6 +23,10 @@ installSteps:
         - "9090"
         - "12798"
       pullOnly: false
+  - file:
+      binary: true
+      filename: dingo-txtop
+      source: files/txtop.sh.gotmpl
 outputs:
   - name: grpc
     description: Dingo gRPC service

--- a/packages/dingo/files/txtop.sh.gotmpl
+++ b/packages/dingo/files/txtop.sh.gotmpl
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Run txtop within the container
+docker exec \
+	-ti \
+	{{ .Package.Name }}-dingo \
+	txtop ${@}


### PR DESCRIPTION
Runs the `txtop` binary in the `dingo` container image.