### PR TITLE
fix(cardano-cli): pass environment variable for network to container

### DIFF
--- a/packages/cardano-cli/files/cardano-cli.sh.gotmpl
+++ b/packages/cardano-cli/files/cardano-cli.sh.gotmpl
@@ -22,6 +22,11 @@ done
 
 _docker_args=()
 
+if [[ $CARDANO_NODE_NETWORK_ID ]]; then
+	# Append to our Docker arguments
+	_docker_args+=( "-e" "CARDANO_NODE_NETWORK_ID=${CARDANO_NODE_NETWORK_ID}" )
+fi
+
 if [[ $CARDANO_NODE_SOCKET_PATH ]]; then
 	# Use the host socket path if specified
 	if [[ ! -e $CARDANO_NODE_SOCKET_PATH ]]; then
@@ -33,6 +38,7 @@ else
 	# Use the default context node socket if no socket path is provided
 	_docker_args+=( "-v" "{{ .Paths.ContextDir }}/node-ipc:/ipc" )
 fi
+_docker_args+=( "-e" "CARDANO_NODE_SOCKET_PATH=/ipc/node.socket" )
 
 if [[ $(uname -s) == Darwin ]]; then
        for _path in "${_darwin_allowed_paths[@]}"; do
@@ -49,7 +55,6 @@ docker run \
 	--rm \
 	-u $(id -u):$(id -g) \
 	-w /host$(pwd) \
-	-e CARDANO_NODE_SOCKET_PATH=/ipc/node.socket \
 	"${_docker_args[@]}" \
 	ghcr.io/blinklabs-io/cardano-cli:{{ .Package.Version }} \
 	"${_args[@]}"


### PR DESCRIPTION
Ensure that `CARDANO_NODE_NETWORK_ID` is passed to the container if it's set on the host when running `cardano-cli` via script.

Thanks to @Quantumplation for pointing this out via Discord.