### PR TITLE
fix(cardano-node): expose correct variable name for cardano network number

### DIFF
--- a/packages/cardano-node/cardano-node-10.2.1.yaml
+++ b/packages/cardano-node/cardano-node-10.2.1.yaml
@@ -37,8 +37,8 @@ installSteps:
       filename: txtop
       source: files/txtop.sh.gotmpl
 outputs:
-  - name: network_magic
-    description: Cardano network magic number
+  - name: network_id
+    description: Cardano network number
     value: '{{ .Context.NetworkMagic }}'
   - name: port
     description: Ouroboros Node-to-Node service


### PR DESCRIPTION
The `cardano-cli` binary looks for `CARDANO_NODE_NETWORK_ID` in the environment, so use that in our output.