### PR TITLE
fix(cardano-cli): preserve args with spaces in wrapper script

### DIFF
--- a/packages/cardano-cli/files/cardano-cli.sh.gotmpl
+++ b/packages/cardano-cli/files/cardano-cli.sh.gotmpl
@@ -16,7 +16,7 @@ while [[ $# -gt 0 ]]; do
 	if [[ $_arg =~ ^/ ]]; then
 		_arg="/host${_arg}"
 	fi
-	_args+=( $_arg )
+	_args+=( "${_arg}" )
 	shift
 done
 


### PR DESCRIPTION
Fixes #179