### PR TITLE
chore: cardano-node 10.5.3

### DIFF
--- a/packages/cardano-node/cardano-node-10.5.3.yaml
+++ b/packages/cardano-node/cardano-node-10.5.3.yaml
@@ -1,0 +1,62 @@
+name: cardano-node
+version: 10.5.3
+description: Cardano node software by Input Output Global
+dependencies:
+  - cardano-config = 20250917
+  - cardano-cli >= 10.8.0.0
+  - mithril-client >= 0.12.11
+installSteps:
+  - docker:
+      containerName: cardano-node
+      image: ghcr.io/blinklabs-io/cardano-node:10.5.3
+      args:
+        - run
+      env:
+        CARDANO_DATABASE_PATH: /data/db
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
+        CARDANO_SOCKET_PATH: /ipc/node.socket
+        RESTORE_NETWORK: 'false'
+        SOCAT_PORT: '30000'
+      binds:
+        - '{{ .Paths.ContextDir }}/config:/opt/cardano/config'
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.DataDir }}/data:/data'
+      ports:
+        - "3001"
+        - "30000"
+        - "12788"
+        - "12798"
+      pullOnly: false
+  - file:
+      binary: true
+      filename: nview
+      source: files/nview.sh.gotmpl
+  - file:
+      binary: true
+      filename: txtop
+      source: files/txtop.sh.gotmpl
+outputs:
+  - name: network_id
+    description: Cardano network number
+    value: '{{ .Context.NetworkMagic }}'
+  - name: port
+    description: Ouroboros Node-to-Node service
+    value: '{{ index (index .Ports "cardano-node") "3001" }}'
+  - name: socket_tcp_port
+    description: Ouroboros Node-to-Client UNIX socket via socat
+    value: '{{ index (index .Ports "cardano-node") "30000" }}'
+  - name: socket_path
+    description: Path to the Cardano Node UNIX socket
+    value: '{{ .Paths.ContextDir }}/node-ipc/node.socket'
+preInstallScript: |
+  set -e
+  test -e {{ .Paths.DataDir }}/data/db/protocolMagicId && exit 0
+  test {{ .Context.Network }} = devnet && echo "Found devnet, skipping Mithril..." && exit 0
+  mithril-client cardano-db download --download-dir {{ .Paths.DataDir }}/data latest
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add cardano-node 10.5.3 as a new package with a Docker-based install, helper scripts, and outputs for network ID, ports, and socket path. Includes a pre-install step to download the latest chain snapshot with mithril (skips for devnet).

- **New Features**
  - Package spec for cardano-node 10.5.3 using ghcr.io/blinklabs-io image.
  - Pre-install snapshot download via mithril unless devnet or DB exists.
  - Helper scripts: nview and txtop.
  - Exposes ports 3001 and 30000, with outputs for network_id, port, socket_tcp_port, and socket_path.
  - Tags: docker, linux, darwin, amd64, arm64.

- **Dependencies**
  - cardano-config = 20250917
  - cardano-cli >= 10.8.0.0
  - mithril-client >= 0.12.11

<sup>Written for commit 9581fb277a085277cc8b8ac0bbeea000751c3042. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

