### PR TITLE
chore: cardano-config 20251014

### DIFF
--- a/packages/cardano-config/cardano-config-20251014.yaml
+++ b/packages/cardano-config/cardano-config-20251014.yaml
@@ -1,0 +1,24 @@
+name: cardano-config
+version: 20251014
+description: Configuration files for the Cardano node by Input Output Global
+installSteps:
+  - docker:
+      containerName: cardano-configs
+      image: ghcr.io/blinklabs-io/cardano-configs:20251014-1
+      pullOnly: true
+outputs:
+  - name: base
+    description: Path to the Cardano Node configuration files
+    value: '{{ .Paths.ContextDir }}/config'
+postInstallScript: |
+  set -e
+  mkdir -p {{ .Paths.ContextDir }}/config
+  docker create --name {{ .Package.Name }}-{{ .Package.ShortName }} ghcr.io/blinklabs-io/cardano-configs:20251014-1 bash
+  docker cp {{ .Package.Name }}-{{ .Package.ShortName }}:/config/{{ .Context.Network }}/ {{ .Paths.ContextDir }}/config/
+  docker rm {{ .Package.Name }}-{{ .Package.ShortName }}
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added cardano-config v20251014 to install Cardano node configs via Docker and expose a base output path. It pulls ghcr.io/blinklabs-io/cardano-configs:20251014-1 and copies /config/<network> into {{ .Paths.ContextDir }}/config for linux/darwin on amd64/arm64.

<sup>Written for commit 7c44ba60190d2a93e1f9af8a22170bcda1e7c57c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

