### PR TITLE
chore: cardano-node-api 0.9.2

### DIFF
--- a/packages/cardano-node-api/cardano-node-api-0.9.2.yaml
+++ b/packages/cardano-node-api/cardano-node-api-0.9.2.yaml
@@ -1,0 +1,33 @@
+name: cardano-node-api
+version: 0.9.2
+description: Multi-protocol API for interfacing with a local Cardano node
+dependencies:
+  - cardano-config >= 20240725
+  - cardano-node >= 9.1.0
+installSteps:
+  - docker:
+      containerName: cardano-node-api
+      image: ghcr.io/blinklabs-io/cardano-node-api:0.9.2
+      env:
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
+      binds:
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/opt/cardano/config'
+      ports:
+        - "8080"
+        - "9090"
+      pullOnly: false
+outputs:
+  - name: grpc
+    description: Cardano Node API gRPC service
+    value: 'http://localhost:{{ index (index .Ports "cardano-node-api") "8080" }}'
+  - name: rest
+    description: Cardano Node API REST service
+    value: 'localhost:{{ index (index .Ports "cardano-node-api") "9090" }}'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds cardano-node-api 0.9.2 package definition with Docker-based install, exposing gRPC (8080) and REST (9090) services. Configurable via CARDANO_NETWORK and node socket bind; depends on cardano-config >= 20240725 and cardano-node >= 9.1.0.

<sup>Written for commit c0bccc2d6d1f5fc930ae997f66f0c068e68205d0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

