### PR TITLE
chore: cardano-config 20251128

### DIFF
--- a/packages/cardano-config/cardano-config-20251128.yaml
+++ b/packages/cardano-config/cardano-config-20251128.yaml
@@ -1,0 +1,24 @@
+name: cardano-config
+version: 20251128
+description: Configuration files for the Cardano node by Input Output Global
+installSteps:
+  - docker:
+      containerName: cardano-configs
+      image: ghcr.io/blinklabs-io/cardano-configs:20251128-1
+      pullOnly: true
+outputs:
+  - name: base
+    description: Path to the Cardano Node configuration files
+    value: '{{ .Paths.ContextDir }}/config'
+postInstallScript: |
+  set -e
+  mkdir -p {{ .Paths.ContextDir }}/config
+  docker create --name {{ .Package.Name }}-{{ .Package.ShortName }} ghcr.io/blinklabs-io/cardano-configs:20251128-1 bash
+  docker cp {{ .Package.Name }}-{{ .Package.ShortName }}:/config/{{ .Context.Network }}/ {{ .Paths.ContextDir }}/config/
+  docker rm {{ .Package.Name }}-{{ .Package.ShortName }}
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds cardano-config v20251128 to fetch network-specific Cardano Node configs via Docker and place them in the package context’s config directory.

Supports Linux and macOS on amd64 and arm64.

<sup>Written for commit 6f253a660cc60857315f917dc4dc6b04088a8299. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cardano configuration package with Docker-based installation and setup capabilities
  * Features automated post-install script for extracting configuration files and deploying to system
  * Available for Linux and Darwin operating systems on amd64 and arm64 processor architectures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->