### PR TITLE
chore: dingo 0.19.0

### DIFF
--- a/packages/dingo/dingo-0.19.0.yaml
+++ b/packages/dingo/dingo-0.19.0.yaml
@@ -1,0 +1,53 @@
+name: dingo
+version: 0.19.0
+description: Dingo Cardano node software by Blink Labs
+dependencies:
+  - cardano-config >= 20251128
+  - cardano-cli >= 10.12.0.0
+installSteps:
+  - docker:
+      containerName: dingo
+      image: ghcr.io/blinklabs-io/dingo:0.19.0
+      command: 
+        - dingo
+      env:
+        CARDANO_CONFIG: /opt/cardano/config/{{ .Context.Network }}/config.json
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_PRIVATE_BIND_ADDR: '0.0.0.0'
+      binds:
+        - '{{ .Paths.ContextDir }}/config:/opt/cardano/config'
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.ContextDir }}/dingo-data:/data/db'
+      ports:
+        - "3001"
+        - "3002"
+        - "9090"
+        - "12798"
+      pullOnly: false
+  - file:
+      binary: true
+      filename: dingo-nview
+      source: files/nview.sh.gotmpl
+  - file:
+      binary: true
+      filename: dingo-txtop
+      source: files/txtop.sh.gotmpl
+outputs:
+  - name: grpc
+    description: Dingo gRPC service
+    value: 'http://localhost:{{ index (index .Ports "dingo") "9090" }}'
+  - name: relay
+    description: Dingo Ouroboros Node-to-Node service
+    value: 'localhost:{{ index (index .Ports "dingo") "3001" }}'
+  - name: socket-path
+    description: Path to the Dingo Ouroboros Node-to-Client UNIX socket
+    value: '{{ .Paths.ContextDir }}/node-ipc/dingo.socket'
+  - name: socket-port
+    description: Dingo Ouroboros Node-to-Client service over TCP
+    value: 'localhost:{{ index (index .Ports "dingo") "3002" }}'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64

--- a/packages/dingo/files/nview.sh.gotmpl
+++ b/packages/dingo/files/nview.sh.gotmpl
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Run nview
+docker exec \
+	-ti \
+	{{ .Package.Name }}-dingo \
+	nview ${@}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Dingo to 0.19.0 to run the latest release. Updates the Docker image to ghcr.io/blinklabs-io/dingo:0.19.0, adds the dingo-0.19.0 manifest, and includes an nview helper script to run nview inside the container.

<sup>Written for commit 905d4eb43a92e4baec192f660f5112f9eeaa6029. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Dingo Cardano node deployment (v0.19.0) with containerized setup, service endpoints for node-to-node relay and inter-process communication, and multi-platform support (Linux/Darwin, x86/ARM).
  * Added utility script for streamlined node command execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->