### PR TITLE
fix(dolos): fix formatting

### DIFF
--- a/packages/dolos/dolos-0.32.0.yaml
+++ b/packages/dolos/dolos-0.32.0.yaml
@@ -10,7 +10,7 @@ installSteps:
   - docker:
       containerName: dolos
       image: ghcr.io/txpipe/dolos:v0.32.0
-      command: 
+      command:
         - dolos
         - daemon
       binds:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed YAML formatting in packages/dolos/dolos-0.32.0.yaml by removing the extra space after the docker "command" key to conform to style and avoid lint warnings.

<sup>Written for commit a5dfc1ebce900bb47883f8a6823a402d6a4c8922. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

