### PR TITLE
chore: cardano-cli 10.14.0.0

### DIFF
--- a/packages/cardano-cli/cardano-cli-10.14.0.0.yaml
+++ b/packages/cardano-cli/cardano-cli-10.14.0.0.yaml
@@ -1,0 +1,18 @@
+name: cardano-cli
+version: 10.14.0.0
+description: CLI software for interfacing with Cardano node by Input Output Global
+installSteps:
+  - docker:
+      containerName: cardano-cli
+      image: ghcr.io/blinklabs-io/cardano-cli:10.14.0.0
+      pullOnly: true
+  - file:
+      binary: true
+      filename: cardano-cli
+      source: files/cardano-cli.sh.gotmpl
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add manifest for cardano-cli v10.14.0.0 to install via Docker (pull-only) and a binary wrapper script. Supports Linux and macOS on both amd64 and arm64.

<sup>Written for commit 4d702a8233293d15aae07bca9570ab46b3d9cedd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for cardano-cli version 10.14.0.0 with multi-platform compatibility (Linux, Darwin, AMD64, ARM64).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->