### PR TITLE
ci: validate versions match package

### DIFF
--- a/.github/workflows/package-validate.yml
+++ b/.github/workflows/package-validate.yml
@@ -16,8 +16,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
-      - run: |
+      - name: Validate filename/content version consistency
+        run: ./scripts/validate-versions.sh
+      - name: Download cardano-up
+        run: |
           set -e
           curl -sLo cardano-up $(curl -s https://api.github.com/repos/blinklabs-io/cardano-up/releases/latest | grep "browser_download_url.*linux-amd64" | cut -d: -f2,3 | tr -d \")
           chmod +x cardano-up
-      - run: ./cardano-up validate -D
+      - name: Validate packages
+        run: ./cardano-up validate -D

--- a/scripts/validate-versions.sh
+++ b/scripts/validate-versions.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Validates filename version matches content version for all packages
+
+set -euo pipefail
+
+ERRORS=0
+CHECKED=0
+
+for file in packages/*/*.yaml; do
+  # Skip if no files match
+  [[ -e "$file" ]] || continue
+
+  # Extract package name from YAML content
+  package_name=$(grep -E '^name:' "$file" | head -1 | awk '{print $2}')
+
+  # Extract version from filename by removing package name prefix
+  # e.g., cardano-cli-10.1.1.0.yaml with name "cardano-cli" -> 10.1.1.0
+  filename=$(basename "$file" .yaml)
+  filename_version="${filename#"${package_name}-"}"
+
+  # Extract version from YAML content
+  content_version=$(grep -E '^version:' "$file" | head -1 | awk '{print $2}')
+
+  CHECKED=$((CHECKED + 1))
+
+  if [[ "$filename_version" != "$content_version" ]]; then
+    echo "ERROR: Version mismatch in $file"
+    echo "  Filename version: $filename_version"
+    echo "  Content version:  $content_version"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+echo ""
+echo "Checked $CHECKED package files"
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo "Found $ERRORS version mismatch(es)"
+  exit 1
+else
+  echo "All versions match"
+  exit 0
+fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a CI check to ensure each package YAML’s filename version matches the version in its content. This fails fast on mismatches to prevent invalid package validations later.

- **New Features**
  - Added scripts/validate-versions.sh to verify version consistency across packages/*.yaml.
  - Integrated the check into the package-validate workflow before running cardano-up validation.

<sup>Written for commit e34ffaf9eca911008975dbe9060bf4c3852b66dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Restructured package validation workflow with explicit named steps for improved logging clarity
* Added version consistency validation between package filenames and their declared content

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->