### PR TITLE
chore: dolos 0.33.0

### DIFF
--- a/packages/dolos/dolos-0.33.0.yaml
+++ b/packages/dolos/dolos-0.33.0.yaml
@@ -1,0 +1,51 @@
+name: dolos
+version: 0.33.0
+description: Dolos is a Cardano data node
+dependencies:
+  - cardano-config >= 20241028
+installSteps:
+  - file:
+      filename: daemon.toml
+      source: files/daemon.toml.gotmpl
+  - docker:
+      containerName: dolos
+      image: ghcr.io/txpipe/dolos:v0.33.0
+      command:
+        - dolos
+        - daemon
+      binds:
+        - '{{ .Paths.DataDir }}:/etc/dolos'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+        - '{{ .Paths.ContextDir }}/dolos-data:/data'
+        - '{{ .Paths.ContextDir }}/dolos-ipc:/ipc'
+      ports:
+        - "30013"
+        - "50051"
+      pullOnly: false
+outputs:
+  - name: grpc
+    description: Dolos gRPC service
+    value: 'http://localhost:{{ index (index .Ports "dolos") "50051" }}'
+  - name: relay
+    description: Dolos Ouroboros Node-to-Node service
+    value: 'localhost:{{ index (index .Ports "dolos") "30013" }}'
+  - name: socket-path
+    description: Path to the Dolos Ouroboros Node-to-Client UNIX socket
+    value: '{{ .Paths.ContextDir }}/dolos-ipc/dolos.socket'
+preInstallScript: |
+  set -e
+  test -e {{ .Paths.ContextDir }}/dolos-data/db/wal && exit 0
+  echo "Downloading snapshot from TxPipe's AWS account (trust me bro)"
+  mkdir -p {{ .Paths.ContextDir }}/dolos-data/db
+  cd {{ .Paths.ContextDir }}/dolos-data/db
+  curl -LO https://dolos-snapshots.s3-accelerate.amazonaws.com/v0/{{ .Context.NetworkMagic }}/full/latest.tar.gz
+  echo "Extracting snapshot"
+  tar vxf latest.tar.gz
+  rm -f latest.tar.gz
+  echo "Snapshot extraction complete"
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Dolos 0.33.0 package manifest to run the node via Docker and expose gRPC and relay endpoints. Includes a first-run snapshot bootstrap to speed up sync.

- **New Features**
  - New manifest (packages/dolos/dolos-0.33.0.yaml) with Docker config, binds for config/data/ipc.
  - Exposes ports 50051 (gRPC) and 30013 (relay) with outputs for URLs and the IPC socket path.
  - Pre-install script downloads and extracts a network-specific snapshot when no WAL is present.
  - Requires cardano-config >= 20241028.

<sup>Written for commit c40f9593b6a77ee64ba656a6a62416973ebbd03e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dolos version 0.33.0 package with Docker container support
  * Includes automatic snapshot initialization from AWS S3
  * Supports multiple platforms (Linux, Darwin) and architectures (amd64, arm64)
  * Provides gRPC, relay, and socket path outputs for integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->