### PR TITLE
chore: dolos 0.33.1

### DIFF
--- a/packages/dolos/dolos-0.33.1.yaml
+++ b/packages/dolos/dolos-0.33.1.yaml
@@ -1,0 +1,51 @@
+name: dolos
+version: 0.33.1
+description: Dolos is a Cardano data node
+dependencies:
+  - cardano-config >= 20241028
+installSteps:
+  - file:
+      filename: daemon.toml
+      source: files/daemon.toml.gotmpl
+  - docker:
+      containerName: dolos
+      image: ghcr.io/txpipe/dolos:v0.33.1
+      command:
+        - dolos
+        - daemon
+      binds:
+        - '{{ .Paths.DataDir }}:/etc/dolos'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+        - '{{ .Paths.ContextDir }}/dolos-data:/data'
+        - '{{ .Paths.ContextDir }}/dolos-ipc:/ipc'
+      ports:
+        - "30013"
+        - "50051"
+      pullOnly: false
+outputs:
+  - name: grpc
+    description: Dolos gRPC service
+    value: 'http://localhost:{{ index (index .Ports "dolos") "50051" }}'
+  - name: relay
+    description: Dolos Ouroboros Node-to-Node service
+    value: 'localhost:{{ index (index .Ports "dolos") "30013" }}'
+  - name: socket-path
+    description: Path to the Dolos Ouroboros Node-to-Client UNIX socket
+    value: '{{ .Paths.ContextDir }}/dolos-ipc/dolos.socket'
+preInstallScript: |
+  set -e
+  test -e {{ .Paths.ContextDir }}/dolos-data/db/wal && exit 0
+  echo "Downloading snapshot from TxPipe's AWS account (trust me bro)"
+  mkdir -p {{ .Paths.ContextDir }}/dolos-data/db
+  cd {{ .Paths.ContextDir }}/dolos-data/db
+  curl -LO https://dolos-snapshots.s3-accelerate.amazonaws.com/v0/{{ .Context.NetworkMagic }}/full/latest.tar.gz
+  echo "Extracting snapshot"
+  tar vxf latest.tar.gz
+  rm -f latest.tar.gz
+  echo "Snapshot extraction complete"
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Dolos 0.33.1 as a package with a Docker-based install that exposes gRPC and Ouroboros endpoints and auto-bootstraps from a snapshot when needed.

- **New Features**
  - New manifest (packages/dolos/dolos-0.33.1.yaml) using ghcr.io/txpipe/dolos:v0.33.1
  - Exposes 50051 (gRPC) and 30013 (Node-to-Node); outputs include gRPC URL, relay address, and UNIX socket path
  - Binds config, data, and IPC directories; installs daemon.toml from template
  - Pre-install script downloads and extracts the latest network snapshot if no WAL is found
  - Declares dependency on cardano-config >= 20241028

<sup>Written for commit 1e92ac564fb06fd6cc0295af683b5d678fa3c094. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

