### PR TITLE
chore: tx-submit-api 0.20.10

### DIFF
--- a/packages/tx-submit-api/tx-submit-api-0.20.10.yaml
+++ b/packages/tx-submit-api/tx-submit-api-0.20.10.yaml
@@ -1,0 +1,27 @@
+name: tx-submit-api
+version: 0.20.10
+description: HTTP transaction submission API gateway for interfacing with a local Cardano node
+dependencies:
+  - cardano-node >= 9.1.0
+installSteps:
+  - docker:
+      containerName: tx-submit-api
+      image: ghcr.io/blinklabs-io/tx-submit-api:0.20.10
+      env:
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
+      binds:
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+      ports:
+        - "8090"
+      pullOnly: false
+outputs:
+  - name: rest
+    description: Tx Submit API REST service
+    value: 'localhost:{{ index (index .Ports "tx-submit-api") "8090" }}'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tx-submit-api v0.20.10 manifest with Docker install steps to run the service and expose the REST endpoint on port 8090. It binds the node socket via node-ipc, forwards CARDANO_NETWORK, and requires cardano-node >= 9.1.0.

<sup>Written for commit 1f35b144b0c505d5a2e119c46f18dff13eb0421c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

