### PR TITLE
ci: fix check-version workflow

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -155,13 +155,7 @@ jobs:
 
             echo "  New version available: $UPSTREAM_VERSION"
 
-            # Check if a PR already exists for this version
             BRANCH_NAME="chore/${PACKAGE}-${UPSTREAM_VERSION}"
-            EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' 2>/dev/null || echo "")
-            if [[ -n "$EXISTING_PR" ]]; then
-              echo "  PR #$EXISTING_PR already exists for this version, skipping"
-              continue
-            fi
 
             # Create new version
             echo "  Creating new version file..."
@@ -183,7 +177,7 @@ jobs:
 
             # Push branch
             echo "  Pushing branch..."
-            git push -u origin "$BRANCH_NAME"
+            git push --force-with-lease -u origin "$BRANCH_NAME"
 
             # Create PR
             echo "  Creating PR..."
@@ -209,11 +203,18 @@ jobs:
           🤖 Generated automatically by check-versions workflow"
             fi
 
-            gh pr create \
+            if ! PR_CREATE_OUTPUT=$(gh pr create \
               --title "chore: ${PACKAGE} ${UPSTREAM_VERSION}" \
               --body "$PR_BODY" \
               --base main \
-              --head "$BRANCH_NAME"
+              --head "$BRANCH_NAME" 2>&1); then
+              if echo "$PR_CREATE_OUTPUT" | grep -qiE 'already exists|pull request already exists'; then
+                echo "  PR already exists for $BRANCH_NAME, skipping create"
+              else
+                echo "$PR_CREATE_OUTPUT"
+                exit 1
+              fi
+            fi
 
             # Return to main branch for next package
             git checkout main

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -157,6 +157,13 @@ jobs:
 
             BRANCH_NAME="chore/${PACKAGE}-${UPSTREAM_VERSION}"
 
+            # Skip if an open PR already exists for this version
+            EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+            if [[ -n "$EXISTING_PR" ]]; then
+              echo "  PR #$EXISTING_PR already open for $BRANCH_NAME, skipping"
+              continue
+            fi
+
             # Create new version
             echo "  Creating new version file..."
             ./scripts/add-version.sh "$PACKAGE" "$UPSTREAM_VERSION"
@@ -175,9 +182,17 @@ jobs:
             git add "packages/${PACKAGE}/${PACKAGE}-${UPSTREAM_VERSION}.yaml"
             git commit -m "chore: ${PACKAGE} ${UPSTREAM_VERSION}"
 
+            # If a stale remote branch exists from a previous failed run
+            # (no open PR was found above), delete it so we can push cleanly
+            # without force-pushing over potential manual commits.
+            if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+              echo "  Stale remote branch $BRANCH_NAME found with no open PR, deleting"
+              git push origin --delete "$BRANCH_NAME"
+            fi
+
             # Push branch
             echo "  Pushing branch..."
-            git push --force-with-lease -u origin "$BRANCH_NAME"
+            git push -u origin "$BRANCH_NAME"
 
             # Create PR
             echo "  Creating PR..."
@@ -203,12 +218,16 @@ jobs:
           🤖 Generated automatically by check-versions workflow"
             fi
 
-            if ! PR_CREATE_OUTPUT=$(gh pr create \
+            PR_CREATED=false
+            if PR_CREATE_OUTPUT=$(gh pr create \
               --title "chore: ${PACKAGE} ${UPSTREAM_VERSION}" \
               --body "$PR_BODY" \
               --base main \
               --head "$BRANCH_NAME" 2>&1); then
-              if echo "$PR_CREATE_OUTPUT" | grep -qiE 'already exists|pull request already exists'; then
+              echo "$PR_CREATE_OUTPUT"
+              PR_CREATED=true
+            else
+              if echo "$PR_CREATE_OUTPUT" | grep -qi 'already exists'; then
                 echo "  PR already exists for $BRANCH_NAME, skipping create"
               else
                 echo "$PR_CREATE_OUTPUT"
@@ -219,7 +238,9 @@ jobs:
             # Return to main branch for next package
             git checkout main
 
-            echo "  PR created successfully!"
+            if [[ "$PR_CREATED" == "true" ]]; then
+              echo "  PR created successfully!"
+            fi
           done
 
           echo ""

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -157,8 +157,10 @@ jobs:
 
             BRANCH_NAME="chore/${PACKAGE}-${UPSTREAM_VERSION}"
 
-            # Skip if an open PR already exists for this version
-            EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+            # Skip if an open PR already exists for this version.
+            # Do not swallow errors here: if the API call fails we must abort
+            # rather than treat it as "no PR" and risk deleting a real branch.
+            EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number')
             if [[ -n "$EXISTING_PR" ]]; then
               echo "  PR #$EXISTING_PR already open for $BRANCH_NAME, skipping"
               continue


### PR DESCRIPTION
Closes: #234 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `check-versions` workflow resilient and safer: skip when an open PR exists, clean up stale branches, and fail fast on API errors. Prevents duplicate PRs, push failures, and accidental branch deletions.

- **Bug Fixes**
  - PR lookup uses `gh pr list --state open`; skip if found, abort on API errors (no silent fallback).
  - Delete stale remote branches with no open PR, then push normally (no force).
  - Handle `gh pr create` output: treat “already exists” as a no-op; only print success when created; fail on unexpected errors with clear logs.

<sup>Written for commit 1c32cefc1f950f1ef06ecd03ec92f42e19281234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the version release workflow to gracefully skip creation when a version pull request already exists.

* **Chores**
  * Enhanced branch synchronization strategy for the version release process to allow more reliable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->