### PR TITLE
chore: cardano-cli 11.0.0.0

### DIFF
--- a/packages/cardano-cli/cardano-cli-11.0.0.0.yaml
+++ b/packages/cardano-cli/cardano-cli-11.0.0.0.yaml
@@ -1,0 +1,18 @@
+name: cardano-cli
+version: 11.0.0.0
+description: CLI software for interfacing with Cardano node by Input Output Global
+installSteps:
+  - docker:
+      containerName: cardano-cli
+      image: ghcr.io/blinklabs-io/cardano-cli:11.0.0.0
+      pullOnly: true
+  - file:
+      binary: true
+      filename: cardano-cli
+      source: files/cardano-cli.sh.gotmpl
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates cardano-cli to version 11.0.0.0
- Upstream release: https://github.com/IntersectMBO/cardano-cli/releases/tag/cardano-cli-11.0.0.0

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `cardano-cli` to 11.0.0.0 by adding a new package manifest that installs from `ghcr.io/blinklabs-io/cardano-cli:11.0.0.0`. Supports Linux and macOS on `amd64` and `arm64` via Docker with the existing `cardano-cli.sh.gotmpl` wrapper.

<sup>Written for commit e75c97387ec12981843b4028b93ea0140a627e81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added package definition for cardano-cli v11.0.0.0, enabling installation via Docker image and local binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->