### PR TITLE
chore: cardano-node 11.0.1

### DIFF
--- a/packages/cardano-node/cardano-node-11.0.1.yaml
+++ b/packages/cardano-node/cardano-node-11.0.1.yaml
@@ -1,0 +1,62 @@
+name: cardano-node
+version: 11.0.1
+description: Cardano node software by Input Output Global
+dependencies:
+  - cardano-config = 20250917
+  - cardano-cli >= 10.8.0.0
+  - mithril-client >= 0.12.11
+installSteps:
+  - docker:
+      containerName: cardano-node
+      image: ghcr.io/blinklabs-io/cardano-node:11.0.1
+      args:
+        - run
+      env:
+        CARDANO_DATABASE_PATH: /data/db
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
+        CARDANO_SOCKET_PATH: /ipc/node.socket
+        RESTORE_NETWORK: 'false'
+        SOCAT_PORT: '30000'
+      binds:
+        - '{{ .Paths.ContextDir }}/config:/opt/cardano/config'
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.DataDir }}/data:/data'
+      ports:
+        - "3001"
+        - "30000"
+        - "12788"
+        - "12798"
+      pullOnly: false
+  - file:
+      binary: true
+      filename: nview
+      source: files/nview.sh.gotmpl
+  - file:
+      binary: true
+      filename: txtop
+      source: files/txtop.sh.gotmpl
+outputs:
+  - name: network_id
+    description: Cardano network number
+    value: '{{ .Context.NetworkMagic }}'
+  - name: port
+    description: Ouroboros Node-to-Node service
+    value: '{{ index (index .Ports "cardano-node") "3001" }}'
+  - name: socket_tcp_port
+    description: Ouroboros Node-to-Client UNIX socket via socat
+    value: '{{ index (index .Ports "cardano-node") "30000" }}'
+  - name: socket_path
+    description: Path to the Cardano Node UNIX socket
+    value: '{{ .Paths.ContextDir }}/node-ipc/node.socket'
+preInstallScript: |
+  set -e
+  test -e {{ .Paths.DataDir }}/data/db/protocolMagicId && exit 0
+  test {{ .Context.Network }} = devnet && echo "Found devnet, skipping Mithril..." && exit 0
+  mithril-client cardano-db download --download-dir {{ .Paths.DataDir }}/data latest
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64

--- a/packages/cardano-node/cardano-node-11.0.1.yaml
+++ b/packages/cardano-node/cardano-node-11.0.1.yaml
@@ -2,9 +2,9 @@ name: cardano-node
 version: 11.0.1
 description: Cardano node software by Input Output Global
 dependencies:
-  - cardano-config = 20250917
-  - cardano-cli >= 10.8.0.0
-  - mithril-client >= 0.12.11
+  - cardano-config = 20260430
+  - cardano-cli >= 11.0.0.0
+  - mithril-client >= 0.12.38
 installSteps:
   - docker:
       containerName: cardano-node


### PR DESCRIPTION
## Summary
- Updates cardano-node to version 11.0.1
- Upstream release: https://github.com/IntersectMBO/cardano-node/releases/tag/11.0.1

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `cardano-node` to 11.0.1 using a new package config and Docker image. Adds Mithril-based DB snapshot bootstrap, installs `nview` and `txtop`, and exposes ports 3001 (N2N), 30000 (socket TCP), 12788, and 12798.

- **Dependencies**
  - `cardano-cli` >= 11.0.0.0
  - `mithril-client` >= 0.12.38
  - `cardano-config` = 20260430

<sup>Written for commit b73b995359e0c7346ad57f8be53754052cbf6904. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cardano node version 11.0.1 is now available with Docker support.
  * Includes automated Mithril database initialization and monitoring utilities.
  * Multi-architecture support (amd64, arm64) across Linux and macOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->