### PR TITLE
chore: dolos 1.2.0

### DIFF
--- a/packages/dolos/dolos-1.2.0.yaml
+++ b/packages/dolos/dolos-1.2.0.yaml
@@ -1,0 +1,51 @@
+name: dolos
+version: 1.2.0
+description: Dolos is a Cardano data node
+dependencies:
+  - cardano-config >= 20241028
+installSteps:
+  - file:
+      filename: daemon.toml
+      source: files/daemon.toml.gotmpl
+  - docker:
+      containerName: dolos
+      image: ghcr.io/txpipe/dolos:v1.2.0
+      command:
+        - dolos
+        - daemon
+      binds:
+        - '{{ .Paths.DataDir }}:/etc/dolos'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+        - '{{ .Paths.ContextDir }}/dolos-data:/data'
+        - '{{ .Paths.ContextDir }}/dolos-ipc:/ipc'
+      ports:
+        - "30013"
+        - "50051"
+      pullOnly: false
+outputs:
+  - name: grpc
+    description: Dolos gRPC service
+    value: 'http://localhost:{{ index (index .Ports "dolos") "50051" }}'
+  - name: relay
+    description: Dolos Ouroboros Node-to-Node service
+    value: 'localhost:{{ index (index .Ports "dolos") "30013" }}'
+  - name: socket-path
+    description: Path to the Dolos Ouroboros Node-to-Client UNIX socket
+    value: '{{ .Paths.ContextDir }}/dolos-ipc/dolos.socket'
+preInstallScript: |
+  set -e
+  test -e {{ .Paths.ContextDir }}/dolos-data/db/wal && exit 0
+  echo "Downloading snapshot from TxPipe's AWS account (trust me bro)"
+  mkdir -p {{ .Paths.ContextDir }}/dolos-data/db
+  cd {{ .Paths.ContextDir }}/dolos-data/db
+  curl -LO https://dolos-snapshots.s3-accelerate.amazonaws.com/v0/{{ .Context.NetworkMagic }}/full/latest.tar.gz
+  echo "Extracting snapshot"
+  tar vxf latest.tar.gz
+  rm -f latest.tar.gz
+  echo "Snapshot extraction complete"
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates dolos to version 1.2.0
- Upstream release: https://github.com/txpipe/dolos/releases/tag/v1.2.0

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `dolos` to 1.2.0 with a new package spec that runs `ghcr.io/txpipe/dolos:v1.2.0`, exposes gRPC (50051) and relay (30013), and auto-downloads a ledger snapshot on first install. Requires `cardano-config >= 20241028` and defines outputs for gRPC, relay, and the UNIX socket.

- **Migration**
  - First install downloads and extracts a snapshot into `dolos-data/db` (needs curl/tar and network access).
  - Ensure ports 50051 and 30013 are available and Docker can bind volumes in the context directory.

<sup>Written for commit 66459996dbba48905be4fd0bb2cca1b6d161a3a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

