### PR TITLE
chore: dingo 0.50.2

### DIFF
--- a/packages/dingo/dingo-0.50.2.yaml
+++ b/packages/dingo/dingo-0.50.2.yaml
@@ -1,0 +1,53 @@
+name: dingo
+version: 0.50.2
+description: Dingo Cardano node software by Blink Labs
+dependencies:
+  - cardano-config >= 20251128
+  - cardano-cli >= 10.12.0.0
+installSteps:
+  - docker:
+      containerName: dingo
+      image: ghcr.io/blinklabs-io/dingo:0.50.2
+      command: 
+        - dingo
+      env:
+        CARDANO_CONFIG: /opt/cardano/config/{{ .Context.Network }}/config.json
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_PRIVATE_BIND_ADDR: '0.0.0.0'
+      binds:
+        - '{{ .Paths.ContextDir }}/config:/opt/cardano/config'
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.ContextDir }}/dingo-data:/data/db'
+      ports:
+        - "3001"
+        - "3002"
+        - "9090"
+        - "12798"
+      pullOnly: false
+  - file:
+      binary: true
+      filename: dingo-nview
+      source: files/nview.sh.gotmpl
+  - file:
+      binary: true
+      filename: dingo-txtop
+      source: files/txtop.sh.gotmpl
+outputs:
+  - name: grpc
+    description: Dingo gRPC service
+    value: 'http://localhost:{{ index (index .Ports "dingo") "9090" }}'
+  - name: relay
+    description: Dingo Ouroboros Node-to-Node service
+    value: 'localhost:{{ index (index .Ports "dingo") "3001" }}'
+  - name: socket-path
+    description: Path to the Dingo Ouroboros Node-to-Client UNIX socket
+    value: '{{ .Paths.ContextDir }}/node-ipc/dingo.socket'
+  - name: socket-port
+    description: Dingo Ouroboros Node-to-Client service over TCP
+    value: 'localhost:{{ index (index .Ports "dingo") "3002" }}'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates dingo to version 0.50.2
- Upstream release: https://github.com/blinklabs-io/dingo/releases/tag/v0.50.2

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `dingo` 0.50.2 package with Docker install steps and outputs for gRPC, node-to-node relay, and node-to-client socket/TCP. Includes `dingo-nview` and `dingo-txtop` scripts and requires `cardano-config >= 20251128` and `cardano-cli >= 10.12.0.0` using `ghcr.io/blinklabs-io/dingo:0.50.2`.

<sup>Written for commit aa8ba9d6c612d116c164f4d5f5e4c2fde12a203e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

