### PR TITLE
chore: cardano-node-api 0.10.1

### DIFF
--- a/packages/cardano-node-api/cardano-node-api-0.10.1.yaml
+++ b/packages/cardano-node-api/cardano-node-api-0.10.1.yaml
@@ -1,0 +1,33 @@
+name: cardano-node-api
+version: 0.10.1
+description: Multi-protocol API for interfacing with a local Cardano node
+dependencies:
+  - cardano-config >= 20240725
+  - cardano-node >= 9.1.0
+installSteps:
+  - docker:
+      containerName: cardano-node-api
+      image: ghcr.io/blinklabs-io/cardano-node-api:0.10.1
+      env:
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
+      binds:
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/opt/cardano/config'
+      ports:
+        - "8080"
+        - "9090"
+      pullOnly: false
+outputs:
+  - name: grpc
+    description: Cardano Node API gRPC service
+    value: 'http://localhost:{{ index (index .Ports "cardano-node-api") "8080" }}'
+  - name: rest
+    description: Cardano Node API REST service
+    value: 'localhost:{{ index (index .Ports "cardano-node-api") "9090" }}'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates cardano-node-api to version 0.10.1
- Upstream release: https://github.com/blinklabs-io/cardano-node-api/releases/tag/v0.10.1

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `cardano-node-api` to 0.10.1 by adding a new runtime manifest that uses the 0.10.1 Docker image and exposes gRPC (8080) and REST (9090) endpoints.

- **Dependencies**
  - Set `cardano-config >= 20240725`
  - Require `cardano-node >= 9.1.0`

<sup>Written for commit 52f6f67fafef3649e319c72027a31d4f007b05a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * cardano-node-api v0.10.1 released and available via Docker with REST and gRPC endpoint support enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->