### PR TITLE
feat(dingo): Configure Dingo for API mode

### DIFF
--- a/packages/dingo/dingo-0.50.2.yaml
+++ b/packages/dingo/dingo-0.50.2.yaml
@@ -14,13 +14,19 @@ installSteps:
         CARDANO_CONFIG: /opt/cardano/config/{{ .Context.Network }}/config.json
         CARDANO_NETWORK: '{{ .Context.Network }}'
         CARDANO_PRIVATE_BIND_ADDR: '0.0.0.0'
+        DINGO_STORAGE_MODE: api
+        DINGO_BLOCKFROST_PORT: '3000'
+        DINGO_MESH_PORT: '8080'
+        DINGO_UTXORPC_PORT: '9090'
       binds:
         - '{{ .Paths.ContextDir }}/config:/opt/cardano/config'
         - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
         - '{{ .Paths.ContextDir }}/dingo-data:/data/db'
       ports:
+        - "3000"
         - "3001"
         - "3002"
+        - "8080"
         - "9090"
         - "12798"
       pullOnly: false
@@ -33,9 +39,15 @@ installSteps:
       filename: dingo-txtop
       source: files/txtop.sh.gotmpl
 outputs:
+  - name: blockfrost
+    description: Dingo Blockfrost-compatible REST API
+    value: 'http://localhost:{{ index (index .Ports "dingo") "3000" }}'
   - name: grpc
     description: Dingo gRPC service
     value: 'http://localhost:{{ index (index .Ports "dingo") "9090" }}'
+  - name: mesh
+    description: Dingo Mesh (Rosetta) REST API
+    value: 'http://localhost:{{ index (index .Ports "dingo") "8080" }}'
   - name: relay
     description: Dingo Ouroboros Node-to-Node service
     value: 'localhost:{{ index (index .Ports "dingo") "3001" }}'


### PR DESCRIPTION
1. I have configured Dingo 0.50.2 to use API storage mode.
2. Enabled Blockfrost, Mesh, and UTxO RPC services.
3. Exposed Blockfrost port 3000 and Mesh port 8080.
4. Added Blockfrost and Mesh endpoint outputs.

Closes #244 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configured `dingo` 0.50.2 for API storage mode and enabled Blockfrost, Mesh, and UTxO RPC services. Aligns with #244 by exposing local REST/gRPC endpoints and adding outputs.

- **New Features**
  - Enable API storage mode (`DINGO_STORAGE_MODE=api`).
  - Expose ports: 3000 (Blockfrost), 8080 (Mesh), 9090 (gRPC/UTxO RPC).
  - Add outputs for Blockfrost and Mesh endpoints.

<sup>Written for commit 7230823894aa1f2935c4dfaf3e38c2fd1ee60fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Blockfrost service endpoint on port 3000
  * Added Mesh service endpoint on port 8080
  * Expanded deployment configuration with new service port mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->