### PR TITLE
chore: ogmios 7.0.0

### DIFF
--- a/packages/ogmios/ogmios-7.0.0.yaml
+++ b/packages/ogmios/ogmios-7.0.0.yaml
@@ -1,0 +1,41 @@
+name: ogmios
+version: 7.0.0
+description: Ogmios, a WebSocket & HTTP server for Cardano, providing a bridge between Cardano nodes and clients.
+dependencies:
+  - cardano-config >= 20240725
+  - cardano-node >= 10.1.0
+installSteps:
+  - docker:
+      containerName: ogmios
+      image: cardanosolutions/ogmios:v7.0.0
+      command:
+        - ogmios
+        - --log-level
+        - info
+        - --host
+        - 0.0.0.0
+        - --port
+        - "1337"
+        - --node-socket
+        - /ipc/node.socket
+        - --node-config
+        - /config/{{ .Context.Network }}/cardano-node/config.json
+      binds:
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+      ports:
+        - "1337"
+      pullOnly: false
+outputs:
+  - name: url
+    description: Ogmios WebSocket & HTTP server URL
+    value: 'http://localhost:{{ index (index .Ports "ogmios") "1337" }}'
+  - name: health_url
+    description: Ogmios health URL
+    value: 'http://localhost:{{ index (index .Ports "ogmios") "1337" }}/health'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates ogmios to version 7.0.0
- Upstream release: https://github.com/CardanoSolutions/ogmios/releases/tag/v7.0.0

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `ogmios` to 7.0.0 using the `cardanosolutions/ogmios:v7.0.0` image. Adds a new package spec that exposes port 1337 and provides `url` and `health_url` outputs.

- **Dependencies**
  - `cardano-node >= 10.1.0`
  - `cardano-config >= 20240725`

<sup>Written for commit d29116411638a6ec1a3d341a347f62628f621372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

