### PR TITLE
chore: tx-submit-api 0.22.0

### DIFF
--- a/packages/tx-submit-api/tx-submit-api-0.22.0.yaml
+++ b/packages/tx-submit-api/tx-submit-api-0.22.0.yaml
@@ -1,0 +1,27 @@
+name: tx-submit-api
+version: 0.22.0
+description: HTTP transaction submission API gateway for interfacing with a local Cardano node
+dependencies:
+  - cardano-node >= 9.1.0
+installSteps:
+  - docker:
+      containerName: tx-submit-api
+      image: ghcr.io/blinklabs-io/tx-submit-api:0.22.0
+      env:
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
+      binds:
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+      ports:
+        - "8090"
+      pullOnly: false
+outputs:
+  - name: rest
+    description: Tx Submit API REST service
+    value: 'localhost:{{ index (index .Ports "tx-submit-api") "8090" }}'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates tx-submit-api to version 0.22.0
- Upstream release: https://github.com/blinklabs-io/tx-submit-api/releases/tag/v0.22.0

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `tx-submit-api` to 0.22.0 and adds a Docker install spec that sets `CARDANO_NETWORK`/`CARDANO_NODE_SOCKET_PATH`, binds the node IPC, and exposes the REST API on port 8090. Requires `cardano-node` >= 9.1.0 and supports Linux/macOS on amd64/arm64.

<sup>Written for commit 2cb1c1aa0feeb8a7dbd4e04fafdfef7c0e4ddc2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

