### PR TITLE
chore: cardano-config 20260623

### DIFF
--- a/packages/cardano-config/cardano-config-20260623.yaml
+++ b/packages/cardano-config/cardano-config-20260623.yaml
@@ -1,0 +1,24 @@
+name: cardano-config
+version: 20260623
+description: Configuration files for the Cardano node by Input Output Global
+installSteps:
+  - docker:
+      containerName: cardano-configs
+      image: ghcr.io/blinklabs-io/cardano-configs:20260623-1
+      pullOnly: true
+outputs:
+  - name: base
+    description: Path to the Cardano Node configuration files
+    value: '{{ .Paths.ContextDir }}/config'
+postInstallScript: |
+  set -e
+  mkdir -p {{ .Paths.ContextDir }}/config
+  docker create --name {{ .Package.Name }}-{{ .Package.ShortName }} ghcr.io/blinklabs-io/cardano-configs:20260623-1 bash
+  docker cp {{ .Package.Name }}-{{ .Package.ShortName }}:/config/{{ .Context.Network }}/ {{ .Paths.ContextDir }}/config/
+  docker rm {{ .Package.Name }}-{{ .Package.ShortName }}
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates cardano-config to version 20260623
- Upstream release: https://github.com/blinklabs-io/cardano-configs/releases/tag/v20260623-1

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `cardano-config` to v20260623 to track the latest upstream release. Adds a new manifest that uses `ghcr.io/blinklabs-io/cardano-configs:20260623-1` and copies per-network node configs into `config/` via Docker.

<sup>Written for commit 1a336fed386068e372b733ff9b51590bd7e9a8c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

