### PR TITLE
chore: cardano-config 20260707

### DIFF
--- a/packages/cardano-config/cardano-config-20260707.yaml
+++ b/packages/cardano-config/cardano-config-20260707.yaml
@@ -1,0 +1,24 @@
+name: cardano-config
+version: 20260707
+description: Configuration files for the Cardano node by Input Output Global
+installSteps:
+  - docker:
+      containerName: cardano-configs
+      image: ghcr.io/blinklabs-io/cardano-configs:20260707-1
+      pullOnly: true
+outputs:
+  - name: base
+    description: Path to the Cardano Node configuration files
+    value: '{{ .Paths.ContextDir }}/config'
+postInstallScript: |
+  set -e
+  mkdir -p {{ .Paths.ContextDir }}/config
+  docker create --name {{ .Package.Name }}-{{ .Package.ShortName }} ghcr.io/blinklabs-io/cardano-configs:20260707-1 bash
+  docker cp {{ .Package.Name }}-{{ .Package.ShortName }}:/config/{{ .Context.Network }}/ {{ .Paths.ContextDir }}/config/
+  docker rm {{ .Package.Name }}-{{ .Package.ShortName }}
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64

--- a/packages/cardano-config/cardano-config-20260707.yaml
+++ b/packages/cardano-config/cardano-config-20260707.yaml
@@ -14,7 +14,7 @@ postInstallScript: |
   set -e
   trap 'docker rm -f {{ .Package.Name }}-{{ .Package.ShortName }} 2>/dev/null || true' EXIT
   mkdir -p {{ .Paths.ContextDir }}/config
-  docker create --name {{ .Package.Name }}-{{ .Package.ShortName }} ghcr.io/blinklabs-io/cardano-configs:20260707-1 bash
+  docker create --name {{ .Package.Name }}-{{ .Package.ShortName }} ghcr.io/blinklabs-io/cardano-configs:20260707-2 bash
   docker cp {{ .Package.Name }}-{{ .Package.ShortName }}:/config/{{ .Context.Network }}/ {{ .Paths.ContextDir }}/config/
   docker rm {{ .Package.Name }}-{{ .Package.ShortName }}
 tags:

--- a/packages/cardano-config/cardano-config-20260707.yaml
+++ b/packages/cardano-config/cardano-config-20260707.yaml
@@ -4,7 +4,7 @@ description: Configuration files for the Cardano node by Input Output Global
 installSteps:
   - docker:
       containerName: cardano-configs
-      image: ghcr.io/blinklabs-io/cardano-configs:20260707-1
+      image: ghcr.io/blinklabs-io/cardano-configs:20260707-2
       pullOnly: true
 outputs:
   - name: base

--- a/packages/cardano-config/cardano-config-20260707.yaml
+++ b/packages/cardano-config/cardano-config-20260707.yaml
@@ -12,6 +12,7 @@ outputs:
     value: '{{ .Paths.ContextDir }}/config'
 postInstallScript: |
   set -e
+  trap 'docker rm -f {{ .Package.Name }}-{{ .Package.ShortName }} 2>/dev/null || true' EXIT
   mkdir -p {{ .Paths.ContextDir }}/config
   docker create --name {{ .Package.Name }}-{{ .Package.ShortName }} ghcr.io/blinklabs-io/cardano-configs:20260707-1 bash
   docker cp {{ .Package.Name }}-{{ .Package.ShortName }}:/config/{{ .Context.Network }}/ {{ .Paths.ContextDir }}/config/


### PR DESCRIPTION
## Summary
- Updates cardano-config to version 20260707
- Upstream release: https://github.com/blinklabs-io/cardano-configs/releases/tag/v20260707-2

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `cardano-config` to 20260707 by adding `packages/cardano-config/cardano-config-20260707.yaml`. Fetches network configs into `config/` using the upstream container.

- **Bug Fixes**
  - Post-install: correct image tag in commands and add EXIT trap for cleanup; use `ghcr.io/blinklabs-io/cardano-configs:20260707-2` consistently.

- **Dependencies**
  - Upstream: https://github.com/blinklabs-io/cardano-configs/releases/tag/v20260707-2

<sup>Written for commit 078816e7ef6e0ebc1c1ba4bac8959759f97ba2a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Cardano configuration package for the 20260707 release.
  * Includes configuration support for Docker and Linux, macOS, and amd64/arm64 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->