### PR TITLE
chore: dolos 1.4.0

### DIFF
--- a/packages/dolos/dolos-1.4.0.yaml
+++ b/packages/dolos/dolos-1.4.0.yaml
@@ -1,0 +1,51 @@
+name: dolos
+version: 1.4.0
+description: Dolos is a Cardano data node
+dependencies:
+  - cardano-config >= 20241028
+installSteps:
+  - file:
+      filename: daemon.toml
+      source: files/daemon.toml.gotmpl
+  - docker:
+      containerName: dolos
+      image: ghcr.io/txpipe/dolos:v1.4.0
+      command:
+        - dolos
+        - daemon
+      binds:
+        - '{{ .Paths.DataDir }}:/etc/dolos'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+        - '{{ .Paths.ContextDir }}/dolos-data:/data'
+        - '{{ .Paths.ContextDir }}/dolos-ipc:/ipc'
+      ports:
+        - "30013"
+        - "50051"
+      pullOnly: false
+outputs:
+  - name: grpc
+    description: Dolos gRPC service
+    value: 'http://localhost:{{ index (index .Ports "dolos") "50051" }}'
+  - name: relay
+    description: Dolos Ouroboros Node-to-Node service
+    value: 'localhost:{{ index (index .Ports "dolos") "30013" }}'
+  - name: socket-path
+    description: Path to the Dolos Ouroboros Node-to-Client UNIX socket
+    value: '{{ .Paths.ContextDir }}/dolos-ipc/dolos.socket'
+preInstallScript: |
+  set -e
+  test -e {{ .Paths.ContextDir }}/dolos-data/db/wal && exit 0
+  echo "Downloading snapshot from TxPipe's AWS account (trust me bro)"
+  mkdir -p {{ .Paths.ContextDir }}/dolos-data/db
+  cd {{ .Paths.ContextDir }}/dolos-data/db
+  curl -LO https://dolos-snapshots.s3-accelerate.amazonaws.com/v0/{{ .Context.NetworkMagic }}/full/latest.tar.gz
+  echo "Extracting snapshot"
+  tar vxf latest.tar.gz
+  rm -f latest.tar.gz
+  echo "Snapshot extraction complete"
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates dolos to version 1.4.0
- Upstream release: https://github.com/txpipe/dolos/releases/tag/v1.4.0

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `dolos` to v1.4.0 with a new package manifest and Docker setup. Exposes gRPC (50051) and Ouroboros relay (30013), configures the IPC socket, and adds a snapshot preinstall to speed bootstrap.

- **Dependencies**
  - Requires `cardano-config >= 20241028`.
  - Uses `ghcr.io/txpipe/dolos:v1.4.0`.

<sup>Written for commit 3590ed133ee6231610dd11b4d0e4f8b78dd2cd60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

