### PR TITLE
chore: kupo 2.12.0

### DIFF
--- a/packages/kupo/kupo-2.12.0.yaml
+++ b/packages/kupo/kupo-2.12.0.yaml
@@ -1,0 +1,49 @@
+name: kupo
+version: 2.12.0
+description: Kupo is fast, lightweight and configurable chain-index for the Cardano blockchain
+dependencies:
+  - cardano-config >= 20240515
+  - cardano-node >= 9.0.0
+installSteps:
+  - docker:
+      containerName: kupo
+      image: cardanosolutions/kupo:v2.12.0
+      command:
+        - kupo
+        - --node-socket
+        - /ipc/node.socket
+        - --host
+        - 0.0.0.0
+        - --port
+        - '1442'
+        - --log-level
+        - Info
+        - --node-config
+        - /config/config.json
+        - --match
+        - '*'
+        - --defer-db-indexes
+        - --since
+        - origin
+        - --workdir
+        - '/db'
+      binds:
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.ContextDir }}/kupo-db:/db'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+      ports:
+        - "1442"
+      pullOnly: false
+outputs:
+  - name: url
+    description: Kupo API URL
+    value: 'http://localhost:{{ index (index .Ports "kupo") "1442" }}'
+  - name: health_url
+    description: Kupo health URL
+    value: 'http://localhost:{{ index (index .Ports "kupo") "1442" }}/health'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates kupo to version 2.12.0
- Upstream release: https://github.com/CardanoSolutions/kupo/releases/tag/v2.12

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `kupo` to v2.12.0 with a new `packages/kupo/kupo-2.12.0.yaml` for Docker-based deployment. Runs on 0.0.0.0:1442 using `cardanosolutions/kupo:v2.12.0`, mounts IPC/config/db, and provides `url` and `health_url` outputs.

<sup>Written for commit bd5b9b6c7ecd35ce8f2fdf67cbe4cfb38693446d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

