### PR TITLE
chore: dingo 0.67.1

### DIFF
--- a/packages/dingo/dingo-0.67.1.yaml
+++ b/packages/dingo/dingo-0.67.1.yaml
@@ -1,0 +1,65 @@
+name: dingo
+version: 0.67.1
+description: Dingo Cardano node software by Blink Labs
+dependencies:
+  - cardano-config >= 20251128
+  - cardano-cli >= 10.12.0.0
+installSteps:
+  - docker:
+      containerName: dingo
+      image: ghcr.io/blinklabs-io/dingo:0.67.1
+      command: 
+        - dingo
+      env:
+        CARDANO_CONFIG: /opt/cardano/config/{{ .Context.Network }}/config.json
+        CARDANO_NETWORK: '{{ .Context.Network }}'
+        CARDANO_PRIVATE_BIND_ADDR: '0.0.0.0'
+        DINGO_STORAGE_MODE: api
+        DINGO_BLOCKFROST_PORT: '3000'
+        DINGO_MESH_PORT: '8080'
+        DINGO_UTXORPC_PORT: '9090'
+      binds:
+        - '{{ .Paths.ContextDir }}/config:/opt/cardano/config'
+        - '{{ .Paths.ContextDir }}/node-ipc:/ipc'
+        - '{{ .Paths.ContextDir }}/dingo-data:/data/db'
+      ports:
+        - "3000"
+        - "3001"
+        - "3002"
+        - "8080"
+        - "9090"
+        - "12798"
+      pullOnly: false
+  - file:
+      binary: true
+      filename: dingo-nview
+      source: files/nview.sh.gotmpl
+  - file:
+      binary: true
+      filename: dingo-txtop
+      source: files/txtop.sh.gotmpl
+outputs:
+  - name: blockfrost
+    description: Dingo Blockfrost-compatible REST API
+    value: 'http://localhost:{{ index (index .Ports "dingo") "3000" }}'
+  - name: grpc
+    description: Dingo gRPC service
+    value: 'http://localhost:{{ index (index .Ports "dingo") "9090" }}'
+  - name: mesh
+    description: Dingo Mesh (Rosetta) REST API
+    value: 'http://localhost:{{ index (index .Ports "dingo") "8080" }}'
+  - name: relay
+    description: Dingo Ouroboros Node-to-Node service
+    value: 'localhost:{{ index (index .Ports "dingo") "3001" }}'
+  - name: socket-path
+    description: Path to the Dingo Ouroboros Node-to-Client UNIX socket
+    value: '{{ .Paths.ContextDir }}/node-ipc/dingo.socket'
+  - name: socket-port
+    description: Dingo Ouroboros Node-to-Client service over TCP
+    value: 'localhost:{{ index (index .Ports "dingo") "3002" }}'
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64


### PR DESCRIPTION
## Summary
- Updates dingo to version 0.67.1
- Upstream release: https://github.com/blinklabs-io/dingo/releases/tag/v0.67.1

## Test plan
- [ ] CI validation passes
- [ ] Manual testing if needed

🤖 Generated automatically by check-versions workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `dingo` to 0.67.1 with a Docker-based package spec that exposes Blockfrost, gRPC, Mesh, relay, and Node-to-Client endpoints via defined ports and outputs.

- **Dependencies**
  - Uses `ghcr.io/blinklabs-io/dingo:0.67.1`
  - Requires `cardano-config` >= 20251128 and `cardano-cli` >= 10.12.0.0

<sup>Written for commit b91344c62c6938009fc1de8859906b195ac5a26d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing Dingo Cardano node version 0.67.1.
  * Configured access to REST, gRPC, relay, and socket endpoints.
  * Added companion tools for node monitoring and diagnostics.
  * Enabled installation across multiple operating system and hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->