### PR TITLE
fix(dolos): update snapshot download URL and fail on HTTP errors

### DIFF
--- a/packages/dolos/dolos-1.6.0.yaml
+++ b/packages/dolos/dolos-1.6.0.yaml
@@ -38,17 +38,26 @@ outputs:
     value: '{{ .Paths.ContextDir }}/dolos-ipc/dolos.socket'
 preInstallScript: |
   set -e
-  # Skip the snapshot download if storage has already been bootstrapped
-  test -e {{ .Paths.ContextDir }}/dolos-data/wal && exit 0
+  DATA_DIR={{ .Paths.ContextDir }}/dolos-data
+  # Skip the snapshot download if the node storage is already populated
+  test -e "$DATA_DIR/wal" && exit 0
   echo "Downloading snapshot from TxPipe"
-  mkdir -p {{ .Paths.ContextDir }}/dolos-data
-  cd {{ .Paths.ContextDir }}/dolos-data
-  rm -f latest.tar.gz
+  # Download and extract into a staging directory so an interrupted run never
+  # leaves a partial snapshot in the live storage path (which would otherwise
+  # be picked up on the next install and start Dolos with incomplete data).
+  STAGING_DIR="$DATA_DIR.tmp"
+  rm -rf "$STAGING_DIR"
+  mkdir -p "$STAGING_DIR"
+  cd "$STAGING_DIR"
   curl --fail --location --retry 3 --retry-delay 5 --output latest.tar.gz \
     https://dolos-snapshots.txpipe.cloud/v3/{{ .Context.NetworkMagic }}/full/latest.tar.gz
   echo "Extracting snapshot"
   tar xzf latest.tar.gz
   rm -f latest.tar.gz
+  # Atomically promote the fully-extracted snapshot into place only after tar
+  # has completed successfully.
+  rm -rf "$DATA_DIR"
+  mv "$STAGING_DIR" "$DATA_DIR"
   echo "Snapshot extraction complete"
 tags:
   - docker

--- a/packages/dolos/dolos-1.6.0.yaml
+++ b/packages/dolos/dolos-1.6.0.yaml
@@ -2,11 +2,11 @@ name: dolos
 version: 1.6.0
 description: Dolos is a Cardano data node
 dependencies:
-  - cardano-config >= 20241028
+  - cardano-config >= 20251128
 installSteps:
   - file:
       filename: daemon.toml
-      source: files/daemon.toml.gotmpl
+      source: files/daemon-v3.toml.gotmpl
   - docker:
       containerName: dolos
       image: ghcr.io/txpipe/dolos:v1.6.0

--- a/packages/dolos/dolos-1.6.0.yaml
+++ b/packages/dolos/dolos-1.6.0.yaml
@@ -1,0 +1,58 @@
+name: dolos
+version: 1.6.0
+description: Dolos is a Cardano data node
+dependencies:
+  - cardano-config >= 20241028
+installSteps:
+  - file:
+      filename: daemon.toml
+      source: files/daemon.toml.gotmpl
+  - docker:
+      containerName: dolos
+      image: ghcr.io/txpipe/dolos:v1.6.0
+      command:
+        - dolos
+        - daemon
+      binds:
+        - '{{ .Paths.DataDir }}:/etc/dolos'
+        - '{{ .Paths.ContextDir }}/config/{{ .Context.Network }}:/config'
+        - '{{ .Paths.ContextDir }}/dolos-data:/data'
+        - '{{ .Paths.ContextDir }}/dolos-ipc:/ipc'
+      ports:
+        - "30013"
+        - "50051"
+        - "3000"
+      pullOnly: false
+outputs:
+  - name: grpc
+    description: Dolos gRPC (UTxORPC) service
+    value: 'http://localhost:{{ index (index .Ports "dolos") "50051" }}'
+  - name: minibf
+    description: Dolos Blockfrost-compatible (minibf) HTTP API
+    value: 'http://localhost:{{ index (index .Ports "dolos") "3000" }}'
+  - name: relay
+    description: Dolos Ouroboros Node-to-Node service
+    value: 'localhost:{{ index (index .Ports "dolos") "30013" }}'
+  - name: socket-path
+    description: Path to the Dolos Ouroboros Node-to-Client UNIX socket
+    value: '{{ .Paths.ContextDir }}/dolos-ipc/dolos.socket'
+preInstallScript: |
+  set -e
+  # Skip the snapshot download if storage has already been bootstrapped
+  test -e {{ .Paths.ContextDir }}/dolos-data/wal && exit 0
+  echo "Downloading snapshot from TxPipe"
+  mkdir -p {{ .Paths.ContextDir }}/dolos-data
+  cd {{ .Paths.ContextDir }}/dolos-data
+  rm -f latest.tar.gz
+  curl --fail --location --retry 3 --retry-delay 5 --output latest.tar.gz \
+    https://dolos-snapshots.txpipe.cloud/v3/{{ .Context.NetworkMagic }}/full/latest.tar.gz
+  echo "Extracting snapshot"
+  tar xzf latest.tar.gz
+  rm -f latest.tar.gz
+  echo "Snapshot extraction complete"
+tags:
+  - docker
+  - linux
+  - darwin
+  - amd64
+  - arm64

--- a/packages/dolos/files/daemon-v3.toml.gotmpl
+++ b/packages/dolos/files/daemon-v3.toml.gotmpl
@@ -1,35 +1,68 @@
 # https://dolos.txpipe.io/configuration
 [upstream]
-network_magic = {{ .Context.NetworkMagic }}
 {{- if eq .Context.Network "mainnet" }}
-peer_address = "backbone.{{ .Context.Network }}.cardanofoundation.org:3001"
-is_testnet = false
-{{ else }}
+peer_address = "backbone.mainnet.cardanofoundation.org:3001"
+{{- else if eq .Context.Network "preprod" }}
+peer_address = "preprod-node.world.dev.cardano.org:30000"
+{{- else if eq .Context.Network "preview" }}
+peer_address = "preview-node.world.dev.cardano.org:30002"
+{{- else }}
 peer_address = "{{ .Context.Network }}-node.play.dev.cardano.org:3001"
+{{- end }}
+
+[chain]
+type = "cardano"
+magic = {{ .Context.NetworkMagic }}
+{{- if eq .Context.Network "mainnet" }}
+is_testnet = false
+{{- else }}
 is_testnet = true
 {{- end }}
- 
-[storage]
-path = "/data/db"
-wal_size = 1000
- 
-[relay]
-listen_address = "[::]:30013"
-magic = {{ .Context.NetworkMagic }}
 
-[sync]
-pull_batch_size = 100
- 
-[submit]
-prune_height = 200
-# validate_phase_1 = false
-# validate_phase_2 = false
- 
+[storage]
+version = "v3"
+path = "/data"
+
 [genesis]
 byron_path = "/config/byron-genesis.json"
 shelley_path = "/config/shelley-genesis.json"
 alonzo_path = "/config/alonzo-genesis.json"
 conway_path = "/config/conway-genesis.json"
+{{- if eq .Context.Network "preview" }}
+force_protocol = 6
+{{- end }}
+
+[sync]
+{{- if eq .Context.Network "preprod" }}
+pull_batch_size = 200
+{{- else }}
+pull_batch_size = 100
+{{- end }}
+{{- if eq .Context.Network "preview" }}
+max_rollback = 25920
+{{- else }}
+max_rollback = 129600
+{{- end }}
+
+[submit]
+{{- if eq .Context.Network "preprod" }}
+prune_height = 10000
+{{- else }}
+prune_height = 200
+{{- end }}
+
+[relay]
+listen_address = "[::]:30013"
+
+[serve.grpc]
+listen_address = "[::]:50051"
+permissive_cors = true
+
+[serve.minibf]
+listen_address = "[::]:3000"
+
+[serve.ouroboros]
+listen_path = "/ipc/dolos.socket"
 
 [mithril]
 {{- if eq .Context.Network "mainnet" }}
@@ -37,26 +70,18 @@ aggregator = "https://aggregator.release-mainnet.api.mithril.network/aggregator"
 {{- else if eq .Context.Network "preprod" }}
 aggregator = "https://aggregator.release-preprod.api.mithril.network/aggregator"
 {{- else if eq .Context.Network "preview" }}
-aggregator = "https://aggregator.prerelease-preview.api.mithril.network/aggregator"
-{{ else }}
-aggregator = "https://aggregator.prerelease-sanchonet.api.mithril.network/aggregator"
+aggregator = "https://aggregator.pre-release-preview.api.mithril.network/aggregator"
+{{- else }}
+aggregator = "https://aggregator.testing-sanchonet.api.mithril.network/aggregator"
 {{- end }}
 {{- if eq .Context.Network "mainnet" }}
 genesis_key = "5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"
-{{ else }}
+{{- else }}
 genesis_key = "5b3132372c37332c3132342c3136312c362c3133372c3133312c3231332c3230372c3131372c3139382c38352c3137362c3139392c3136322c3234312c36382c3132332c3131392c3134352c31332c3233322c3234332c34392c3232392c322c3234392c3230352c3230352c33392c3233352c34345d"
 {{- end }}
- 
-[serve.grpc]
-listen_address = "[::]:50051"
-permissive_cors = true
- 
-[serve.ouroboros]
-listen_path = "/ipc/dolos.socket"
-magic = {{ .Context.NetworkMagic }}
- 
+
 [logging]
-max_level = "debug"
+max_level = "info"
 include_tokio = false
 include_pallas = false
 include_grpc = false

--- a/packages/dolos/files/daemon.toml.gotmpl
+++ b/packages/dolos/files/daemon.toml.gotmpl
@@ -1,35 +1,68 @@
 # https://dolos.txpipe.io/configuration
 [upstream]
-network_magic = {{ .Context.NetworkMagic }}
 {{- if eq .Context.Network "mainnet" }}
-peer_address = "backbone.{{ .Context.Network }}.cardanofoundation.org:3001"
-is_testnet = false
-{{ else }}
+peer_address = "backbone.mainnet.cardanofoundation.org:3001"
+{{- else if eq .Context.Network "preprod" }}
+peer_address = "preprod-node.world.dev.cardano.org:30000"
+{{- else if eq .Context.Network "preview" }}
+peer_address = "preview-node.world.dev.cardano.org:30002"
+{{- else }}
 peer_address = "{{ .Context.Network }}-node.play.dev.cardano.org:3001"
+{{- end }}
+
+[chain]
+type = "cardano"
+magic = {{ .Context.NetworkMagic }}
+{{- if eq .Context.Network "mainnet" }}
+is_testnet = false
+{{- else }}
 is_testnet = true
 {{- end }}
- 
-[storage]
-path = "/data/db"
-wal_size = 1000
- 
-[relay]
-listen_address = "[::]:30013"
-magic = {{ .Context.NetworkMagic }}
 
-[sync]
-pull_batch_size = 100
- 
-[submit]
-prune_height = 200
-# validate_phase_1 = false
-# validate_phase_2 = false
- 
+[storage]
+version = "v3"
+path = "/data"
+
 [genesis]
 byron_path = "/config/byron-genesis.json"
 shelley_path = "/config/shelley-genesis.json"
 alonzo_path = "/config/alonzo-genesis.json"
 conway_path = "/config/conway-genesis.json"
+{{- if eq .Context.Network "preview" }}
+force_protocol = 6
+{{- end }}
+
+[sync]
+{{- if eq .Context.Network "preprod" }}
+pull_batch_size = 200
+{{- else }}
+pull_batch_size = 100
+{{- end }}
+{{- if eq .Context.Network "preview" }}
+max_rollback = 25920
+{{- else }}
+max_rollback = 129600
+{{- end }}
+
+[submit]
+{{- if eq .Context.Network "preprod" }}
+prune_height = 10000
+{{- else }}
+prune_height = 200
+{{- end }}
+
+[relay]
+listen_address = "[::]:30013"
+
+[serve.grpc]
+listen_address = "[::]:50051"
+permissive_cors = true
+
+[serve.minibf]
+listen_address = "[::]:3000"
+
+[serve.ouroboros]
+listen_path = "/ipc/dolos.socket"
 
 [mithril]
 {{- if eq .Context.Network "mainnet" }}
@@ -37,26 +70,18 @@ aggregator = "https://aggregator.release-mainnet.api.mithril.network/aggregator"
 {{- else if eq .Context.Network "preprod" }}
 aggregator = "https://aggregator.release-preprod.api.mithril.network/aggregator"
 {{- else if eq .Context.Network "preview" }}
-aggregator = "https://aggregator.prerelease-preview.api.mithril.network/aggregator"
-{{ else }}
-aggregator = "https://aggregator.prerelease-sanchonet.api.mithril.network/aggregator"
+aggregator = "https://aggregator.pre-release-preview.api.mithril.network/aggregator"
+{{- else }}
+aggregator = "https://aggregator.testing-sanchonet.api.mithril.network/aggregator"
 {{- end }}
 {{- if eq .Context.Network "mainnet" }}
 genesis_key = "5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"
-{{ else }}
+{{- else }}
 genesis_key = "5b3132372c37332c3132342c3136312c362c3133372c3133312c3231332c3230372c3131372c3139382c38352c3137362c3139392c3136322c3234312c36382c3132332c3131392c3134352c31332c3233322c3234332c34392c3232392c322c3234392c3230352c3230352c33392c3233352c34345d"
 {{- end }}
- 
-[serve.grpc]
-listen_address = "[::]:50051"
-permissive_cors = true
- 
-[serve.ouroboros]
-listen_path = "/ipc/dolos.socket"
-magic = {{ .Context.NetworkMagic }}
- 
+
 [logging]
-max_level = "debug"
+max_level = "info"
 include_tokio = false
 include_pallas = false
 include_grpc = false


### PR DESCRIPTION
Closes: #253 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `dolos` to v1.6.0 and fix snapshot bootstrap by switching to the v3 snapshot URL keyed by network magic, with strict HTTP failure handling, retries, and atomic extraction. Refreshes `daemon.toml` to match 1.6.0 defaults with new services and per-network tuning.

- **Bug Fixes**
  - Snapshot download now uses the v3 URL with `curl --fail --location --retry 3 --retry-delay 5`, extracting in a staging dir and atomically moving to avoid partial data.
  - Skips download when storage is already populated (`wal` exists).

- **Refactors**
  - Bump image to `ghcr.io/txpipe/dolos:v1.6.0` and adopt v3 storage at `/data`.
  - Refresh config: add gRPC and minibf services, relay and socket outputs; expose ports 50051, 3000, 30013; update peers, preview protocol override, Mithril aggregator URLs; tune sync/submit; set logging to `info`.

<sup>Written for commit 67519078dcdc5d9291d53eadaba3ccf7b48dc0ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-up-packages/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Dolos version 1.6.0.
  * Added network-specific configuration for mainnet, preprod, preview, and other environments.
  * Exposed gRPC, Blockfrost-compatible HTTP, Ouroboros relay, and UNIX socket endpoints.

* **Bug Fixes**
  * Improved snapshot installation reliability by staging downloads before replacing live node data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->